### PR TITLE
Improve LDRParser#findFile method

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ A basic file looks like this:
  * Support for various encodings.
  * Support for part metas and comment processing.
  * Document the code
- * Make file-searching a bit more foolproof, though it is remarkably fast at the moment.
  * Conversion back to LDR files.
  * Flattening of format, so that the only things stored are those necessary for drawing. (Vertices, Indices, and Colors, really.) Requires decent knowledge of Linear Algebra and 4x4 Matrices.
 

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -38,7 +38,7 @@ class LDRParser:
 
     options = {
         "skip": [],
-        "logLevel": 0,
+        "logLevel": 0
     }
 
     _parts = {}
@@ -179,43 +179,51 @@ class LDRParser:
         }
         return myDef
 
-    # TODO: Make less-ugly. It's remarkably fast at the moment though.
-    def findFile(self, filePath):
+    def findFile(self, partPath):
+        """Locate a part in the LDraw parts installation.
+
+        @param {String} partPath The part name that needs to be located.
+        @return {String} The full file path to the given part.
+        """
         locatedFile = None
 
-        # Try files relative to the main file first.
-        if not locatedFile:
-            if os.path.isfile(os.path.dirname(os.path.abspath(self.startFile))+os.path.sep+filePath):
-                locatedFile = filePath
+        # In the order we search:
+        #   * Files relative to the main file
+        #   * Models folder
+        #   * Unofficial parts (parts and p subfolders)
+        #   * Parts folder
+        #   * p folder
+        paths = [
+            os.path.join(os.path.dirname(os.path.abspath(self.startFile)),
+                         partPath),
+            os.path.join(self.libraryLocation, "models", partPath),
+            os.path.join(self.libraryLocation, "Unofficial", "parts",
+                         partPath),
+            os.path.join(self.libraryLocation, "Unofficial", "p", partPath),
+            os.path.join(self.libraryLocation, "parts", partPath),
+            os.path.join(self.libraryLocation, "p", partPath)
+        ]
 
-        # Try the immediate paths first, sub-directories are often specified using the path separator.
-        if not locatedFile:
-            if os.path.isfile(self.libraryLocation+os.path.sep+"parts"+os.path.sep+filePath):
-                locatedFile = self.libraryLocation+os.path.sep+"parts"+os.path.sep+filePath
-
-        if not locatedFile:
-            if os.path.isfile(self.libraryLocation+os.path.sep+"p"+os.path.sep+filePath):
-                locatedFile = self.libraryLocation+os.path.sep+"p"+os.path.sep+filePath
-
-        if not locatedFile:
-            if os.path.isfile(self.libraryLocation+os.path.sep+"Unofficial"+os.path.sep+"parts"+filePath):
-                locatedFile = self.libraryLocation+os.path.sep+"Unofficial"+os.path.sep+"parts"+filePath
+        for path in paths:
+            if os.path.isfile(path):
+                locatedFile = path
+                break
 
         # Failing that, recursively search through every directory
         # in the library folder for the file.
         if not locatedFile:
-            for file in locate(os.path.basename(filePath),
+            for file in locate(os.path.basename(partPath),
                                self.libraryLocation):
                 locatedFile = file
                 break
 
         # Try the current directory.
         if not locatedFile:
-            if os.path.isfile(filePath):
-                locatedFile = filePath
+            if os.path.isfile(partPath):
+                locatedFile = partPath
 
         if not locatedFile:
-            self.log("Error: File not found: {0}".format(filePath), 1)
+            self.log("Error: File not found: {0}".format(partPath), 1)
 
         return locatedFile
 


### PR DESCRIPTION
This improves the `findFile()` method in a few ways
- Use `os.path.join()` for constructing paths
- Store the paths in an list and loop over each path in it when finding the part
- Correct search order (the order [I have here](https://github.com/le717/LDR-Importer/blob/be29cf1711906a37fdaeb2b34424e3cf46cb8803/import_ldraw.py#L1110-L1152) is correct, as an LDraw dev helped align it to spec)
- Search the `models` and `Unofficial/p` folder too

This does not tackle the new high/low res folders (`48` and `8`, respectively), nor does it cover the LSynth parts. The former should be added ASAP (I can add them in this PR if you wish), but the latter is in no hurry (probably open an issue or something as a reminder).
