### PR TITLE
Various minor changes

### DIFF
--- a/LDRParser.py
+++ b/LDRParser.py
@@ -24,6 +24,8 @@ SOFTWARE.
 
 """
 
+from __future__ import print_function
+
 import sys
 import json
 import pprint

--- a/LDRParser.py
+++ b/LDRParser.py
@@ -33,10 +33,13 @@ from libldrparser import LDRParser
 if __name__ == '__main__':
 
     def printHelp():
-        print("[LDRParser {0}] Usage: python ldrparser.py PATH/TO/LDRAW/LIBRARY PATH/TO/FILE/FOR/PARSING [options]"
+        print("""\n[LDRParser {0}]
+Usage: ldrparser.py PATH/TO/LDRAW/LIBRARY PATH/TO/FILE/FOR/PARSING [options]"""
               .format(".".join(LDRParser.version)))
-        print("Options:")
-        print("  -s= [Comma-separated string. Values: COMMENT,SUBPART,LINE,TRI,QUAD,OPTLINE] Line control codes to skip.")
+        print("\nOptions:")
+        print("""  -s= [Comma-separated string. Values:
+       {0}] Line control codes to skip.""".format(
+              ",".join(LDRParser.ControlCodes)))
         print("  -l=0 [0-5] Log Level")
         print("  -o=dict [dict, json] Format to output")
         print("  -m=false [true|false] Minify output")

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -22,6 +22,8 @@ SOFTWARE.
 
 """
 
+from __future__ import print_function
+
 import os
 import fnmatch
 
@@ -127,7 +129,7 @@ class LDRParser:
                 elif code == "OPTLINE":
                     if "optlines" not in definition:
                         definition["optlines"] = []
-                    definition["optlines"].append(self.parseQuad(line))
+                    definition["optlines"].append(self.parseOptLine(line))
 
         return definition
 


### PR DESCRIPTION
- Now PEP8 compliant
- Use [`with`](https://triangle717.wordpress.com/tutorials/python/with/) for reading files
- Support the Python 3 `print()` when running [under Python 2](https://triangle717.wordpress.com/tutorials/python/2a3printinput/#print) ([details](https://triangle717.wordpress.com/2015/02/11/python-future-module/))
- Make help text look a bit better
- Added many new code comments and two new docstrings
- Make `findFiles()` search the current directory as the first search
- Remove the unused `getCode()` method
- Make the part cache a private member of the object
- Set the `libraryLocation` and `startFile` defaults in the constructor (though IMO, there should be no defaults at all)
- Move the `log()` method right below the constructor (it's considered good practice to define your functions before calling them)
- Strip the `0` from comment lines (small thing before proper parsing is implemented)
- Use proper `parseOptLine()` method for parsing the optional lines
