### PR TITLE
Improve public API

### DIFF
--- a/LDRParser.py
+++ b/LDRParser.py
@@ -71,8 +71,8 @@ Usage: ldrparser.py PATH/TO/LDRAW/LIBRARY PATH/TO/FILE/FOR/PARSING [options]"""
             printHelp()
             sys.exit(0)
 
-    parser = LDRParser(sys.argv[1], sys.argv[2], options)
-    out = parser.fromLDR()
+    parser = LDRParser(sys.argv[1], options)
+    out = parser.parse(sys.argv[2])
 
     if options["output"] == "dict":
         if options["minify"]:

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -37,9 +37,9 @@ class LDRParser:
         "logLevel": 0
     }
 
-    def __init__(self, libraryLocation="", startFile="", options={}):
+    def __init__(self, libraryLocation, options={}):
         self.libraryLocation = libraryLocation
-        self.startFile = startFile
+        self.modelFile = None
         self.__parts = {}
         self.options.update(options)
 
@@ -55,14 +55,17 @@ class LDRParser:
         if self.options["logLevel"] >= level:
             print("[LDRParser] {0}".format(string))
 
-    def fromLDR(self):
+    def parse(self, modelFile):
+        # Set the model to be read
+        self.modelFile = modelFile
+
         # Display the line types we are going to skip parsing.
         if len(self.options["skip"]) > 0:
             self.log("Skip: {0}".format(", ".join(self.options["skip"])), 5)
 
         # This can load any valid file on the LDraw path
         # with the specified name, not just a full path.
-        filePath = self.findFile(self.startFile)
+        filePath = self.findFile(self.modelFile)
 
         # The file could not be found.
         if filePath is None:
@@ -221,7 +224,7 @@ class LDRParser:
         #  * Parts folder
         #  * p folder
         paths = [
-            os.path.join(os.path.dirname(os.path.abspath(self.startFile)),
+            os.path.join(os.path.dirname(os.path.abspath(self.modelFile)),
                          partPath),
             os.path.join(self.libraryLocation, "models", partPath),
             os.path.join(self.libraryLocation, "Unofficial", "parts",


### PR DESCRIPTION
Let me explain this change.

Right now, we set both the LDraw library path and the model to be read in the constructor, then call `fromLDR()` to begin reading. However, this hampers the benefits of cache, as we have to make a new instance, thus a new cache, for every new model we want to read.

By setting the model to be read in `parse()` (a renamed `fromLDR()`, I'll explain in a moment) which in turns modifies the object, we can read multiple files using the same instance, thereby making much greater use of our existing (and admittedly large) cache. This might also help if you choose a recursive method for parsing MPD files.

`fromLDR()` was renamed because we really don't need multiple entry points (`fromMPD()`?) for similar file types (.dat/.ldr VS .mpd). We can perform the model type detection ourselves. I will say the rename was a toss-up between `parse()` or `read()`. If you think it should be called something different, speak up. :)

This PR also removes the default value for `self.libraryLocation`. Detecting the path is out of scope (this is a _parser_). If someone is going to use this, they need to already have a defined LDraw installation.
