### PR TITLE
More small fixes

### DIFF
--- a/LDRParser.py
+++ b/LDRParser.py
@@ -44,7 +44,7 @@ Usage: ldrparser.py PATH/TO/LDRAW/LIBRARY PATH/TO/FILE/FOR/PARSING [options]"""
               ",".join(LDRParser.ControlCodes)))
         print("  -l=0 [0-5] Log Level")
         print("  -o=dict [dict, json] Format to output")
-        print("  -m=false [true|false] Minify output")
+        print("  -m Minify output")
         print("  -h, --help Show this help text.")
 
     if len(sys.argv) < 3:
@@ -65,8 +65,8 @@ Usage: ldrparser.py PATH/TO/LDRAW/LIBRARY PATH/TO/FILE/FOR/PARSING [options]"""
             options["logLevel"] = int(arg[3:])
         elif "-o=" in arg:
             options["output"] = arg[3:].lower()
-        elif "-m=" in arg:
-            options["minify"] = arg[3:].lower() in ("true", "yes", "t", "1")
+        elif "-m" in arg:
+            options["minify"] = True
         elif "-h" in arg or "--help" in arg:
             printHelp()
             sys.exit(0)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and any options you may like.
 **Options:**
 
 * `-s= [Comma-separated string. Values: COMMENT,SUBPART,LINE,TRI,QUAD,OPTLINE]` Line control codes to skip.
-* `-m=false [false|true]` Whether to minify the output (don't pretty-print it) or not.
+* `-m` Whether to minify the output (don't pretty-print it) or not.
 * `-o=json [json|dict]` Output format: JSON or Python Dictionary.
 * `-l=0 [0-5]` Logging Level. Log level 0 displays nothing other than the output, 5 is verbose.
 
@@ -31,14 +31,15 @@ From your project, import LDRParser from libldrparser (`from libldrparser import
 
 Create an instance of LDRParser, this allows the part cache to persist across multiple conversions for a model and greatly speeds up subsequent runs.
 ```python
-parser = LDRParser("PATH/TO/LDRAW/LIBRARY", "PATH/TO/TARGET/MODEL", {
+parser = LDRParser("PATH/TO/LDRAW/LIBRARY", {
   # Options
-  "skip": [], # A list of line control codes to skip. Valid codes: ("COMMENT", "SUBPART", "LINE", "TRI", "QUAD", "OPTLINE")
+  "skip": [],
   "logLevel": 0
 })
 
-# Do the actual conversion. output is a python dictionary using the format described below.
-output = parser.fromLDR()
+# Do the actual conversion.
+# Output is a python dictionary using the format described below.
+output = parser.parse("PATH/TO/TARGET/MODEL")
 ```
 
 ##Format:
@@ -55,8 +56,9 @@ A basic file looks like this:
         {
           // The id of the part in the parts object.
           "partId": "4-4edge.dat"
-          "color": "16", // Raw color from the LDR file. I may add conversion for this in the future.
-          "matrix": [ // Transformation martix for this sub-part.
+          "color": "16", // Raw color from the LDR file.
+          // Transformation martix for this sub-part.
+          "matrix": [
             "4",
             "0",
             "0",
@@ -76,7 +78,8 @@ A basic file looks like this:
           ],
         }
       ],
-      "lines": [ // Defines a line from pos1 to pos2.
+      // Defines a line from pos1 to pos2.
+      "lines": [
         {
           "color": "16",
           "pos1": [
@@ -91,7 +94,8 @@ A basic file looks like this:
           ],
         }
       ],
-      "tris": [ // Defines a triangle. Vertices are pos1, pos2, and pos3.
+      // Defines a triangle. Vertices are pos1, pos2, and pos3.
+      "tris": [
         {
           "color": "16",
           "pos1": [
@@ -111,7 +115,8 @@ A basic file looks like this:
           ],
         },
       ],
-      "quads": [ // Defines a quad. Vertices are pos1, pos2, pos3, and pos4.
+      // Defines a quad. Vertices are pos1, pos2, pos3, and pos4.
+      "quads": [
         {
           "color": "16",
           "pos1": [
@@ -136,7 +141,10 @@ A basic file looks like this:
           ]
         },
       ],
-      "optlines": [ // Defines a line which is only visible based on certain rules. See http://www.ldraw.org/article/218.html, line type 5. pos1 and 2 define the line vertices, ctl1 and 2 are the control points.
+      // Defines a line which is only visible based on certain rules.
+      // See http://www.ldraw.org/article/218.html,
+      // line type 5. pos1 and 2 define the line vertices, ctl1 and 2 are the control points.
+      "optlines": [
         {
           "color": "16",
           "pos1": [
@@ -192,7 +200,6 @@ A basic file looks like this:
 ```
 
 ##TODO:
- * Better code formatting. Use PEP8.
  * Support for mpd files.
  * Support for various encodings.
  * Support for part metas and comment processing.

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -69,7 +69,7 @@ class LDRParser:
 
         # Display the line types we are going to skip parsing.
         if len(self.options["skip"]) > 0:
-            self.log("Skip: {0}".format(", ".join(self.options["skip"])), 5)
+            self.log("Skip line type(s): {0}".format(", ".join(self.options["skip"])), 5)
 
         # This can load any valid file on the LDraw path
         # with the specified name, not just a full path.

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -27,6 +27,8 @@ from __future__ import print_function
 import os
 import fnmatch
 
+__all__ = ("LDRParser")
+
 
 class LDRParser:
     version = ("0", "1", "0")
@@ -42,6 +44,12 @@ class LDRParser:
         self.modelFile = None
         self.__parts = {}
         self.options.update(options)
+
+    @staticmethod
+    def __locate(pattern, root=os.curdir):
+        for path, dirs, files in os.walk(os.path.abspath(root)):
+            for filename in fnmatch.filter(files, pattern):
+                yield os.path.join(path, filename)
 
     def log(self, string, level=0):
         """Log debug messages to the console.
@@ -70,7 +78,7 @@ class LDRParser:
         # The file could not be found.
         if filePath is None:
             self.log("Critical Error - File Not Found: {0}".format(
-                     filePath), 0)
+                     self.modelFile), 0)
             return None
 
         # Begin parsing the model and all the parts.
@@ -155,8 +163,7 @@ class LDRParser:
 
             # We have a file path.
             if filePath is not None:
-                self.log("Caching Part: {0}".format(
-                         self.findFile(myDef["partId"])), 4)
+                self.log("Caching Part: {0}".format(filePath), 4)
 
                 # Read and cache the part contents.
                 with open(filePath, "r") as f:
@@ -248,8 +255,8 @@ class LDRParser:
         # Failing that, recursively search through every directory
         # in the library folder for the file.
         if not locatedFile:
-            for f in locate(os.path.basename(partPath),
-                            self.libraryLocation):
+            for f in self.__locate(os.path.basename(partPath),
+                                   self.libraryLocation):
                 locatedFile = f
                 break
 
@@ -270,9 +277,3 @@ class LDRParser:
         return partName.lower().replace("\\",
                                         os.path.sep).replace("/",
                                                              os.path.sep)
-
-
-def locate(pattern, root=os.curdir):
-    for path, dirs, files in os.walk(os.path.abspath(root)):
-        for filename in fnmatch.filter(files, pattern):
-            yield os.path.join(path, filename)


### PR DESCRIPTION
- Readme updates
- Simplify `-m` flag to simply passing it instead of it having a value (P.S. You should look into [`argparse`](https://docs.python.org/3/library/argparse.html). It's really easy to use, I have actual usage I can show you)
- Add `__all__` tuple to restrict what gets imported wildcard import is used
- Small log fixes. If a part could not be found, None was displayed as the part name. Also, do not  run `self.findFile()` just to say we are caching the part (this one change decreases runtime, will help if `locate()` is ever hit, and was a bug anyway. :P)
- Make `locate()` a private [static method](http://stackoverflow.com/a/735978). This is a debatable change, as some say this can be done just as easily using a global function (as it was before), but I argue for this way as it is best to keep methods that pertain to the object's operations within the object, _especially_ if it's only intended for internal use and has no meaning outside the object context (which `locate()` falls directly into).
