### PR TITLE
Two fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ A basic file looks like this:
 
 ##TODO:
  * Support for mpd files.
- * Support for various encodings.
  * Support for part metas and comment processing.
  * Document the code
  * Conversion back to LDR files.

--- a/libldrparser.py
+++ b/libldrparser.py
@@ -51,6 +51,22 @@ class LDRParser:
             for filename in fnmatch.filter(files, pattern):
                 yield os.path.join(path, filename)
 
+    @staticmethod
+    def __convert(vals):
+        for i in range(0, len(vals)):
+            line = vals[i]
+            # Floats
+            if "." in line and "dat" not in line.lower():
+                vals[i] = float(line)
+            else:
+                try:
+                    # Integers
+                    vals[i] = int(line)
+                # Strings
+                except ValueError:
+                    pass
+        return vals
+
     def log(self, string, level=0):
         """Log debug messages to the console.
 
@@ -151,7 +167,7 @@ class LDRParser:
 
     def parsePart(self, line):
         myDef = {}
-        splitLine = line.split()
+        splitLine = self.__convert(line.split())
 
         myDef["color"] = splitLine[1]
         myDef["matrix"] = (
@@ -195,7 +211,7 @@ class LDRParser:
         return comment
 
     def parseLine(self, line):
-        splitLine = line.split()
+        splitLine = self.__convert(line.split())
         myDef = {
             "color": splitLine[1],
             "pos1": (splitLine[2], splitLine[3], splitLine[4]),
@@ -204,7 +220,7 @@ class LDRParser:
         return myDef
 
     def parseTri(self, line):
-        splitLine = line.split()
+        splitLine = self.__convert(line.split())
         myDef = {
             "color": splitLine[1],
             "pos1": (splitLine[2], splitLine[3], splitLine[4]),
@@ -214,7 +230,7 @@ class LDRParser:
         return myDef
 
     def parseQuad(self, line):
-        splitLine = line.split()
+        splitLine = self.__convert(line.split())
         myDef = {
             "color": splitLine[1],
             "pos1": (splitLine[2], splitLine[3], splitLine[4]),
@@ -225,7 +241,7 @@ class LDRParser:
         return myDef
 
     def parseOptLine(self, line):
-        splitLine = line.split()
+        splitLine = self.__convert(line.split())
         myDef = {
             "color": splitLine[1],
             "pos1": (splitLine[2], splitLine[3], splitLine[4]),


### PR DESCRIPTION
- Convert all numbers (in a matrix, color codes, and pos*) to intergers/floats. Before, only a few (if any) were numbers and the rest were strings (I've been meaning to report and/or fix this since my past PR in May).
- Detect and store the part type (Part, Subpart, Primitive, etc). This required a tad refactoring to always parse comments in order to get the data and just store them if needed.
