### PR TITLE
Only construct the search path once

### DIFF
--- a/libldrparser.py
+++ b/libldrparser.py
@@ -238,7 +238,7 @@ class LDRParser:
         # Strip the prefix
         comment = comment.strip().lstrip("0 ")
 
-        # Filter out archaic META commands, blank lines, and comments
+        # Filter out META commands, blank lines, and comments
         # See http://www.ldraw.org/article/218/#meta
         lineFilter = ("", "STEP", "WRITE", "PRINT", "CLEAR", "PAUSE", "SAVE")
         if comment in lineFilter or comment.startswith("//"):
@@ -299,7 +299,7 @@ class LDRParser:
             locatedFile = partPath
 
         # Revise the search path just a little bit
-        # to append current the part name
+        # to append the current part name.
         paths = [os.path.join(path, partPath) for path in self.__searchPath]
 
         # Now check the search path for the file.


### PR DESCRIPTION
While working on #10 I found this little bit here could be improved to have better performance. We don't need to build the search path for every part, just once before we begin the parsing.
